### PR TITLE
add workaround for userdev bug

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,3 +107,12 @@ tasks.withType<Jar> {
         ))
     }
 }
+
+// workaround for userdev bug
+tasks.create("copyResourceToClasses", Copy::class) {
+    tasks.classes.get().dependsOn(this)
+    dependsOn(tasks.processResources.get())
+    onlyIf { gradle.taskGraph.hasTask(tasks.getByName("prepareRuns")) }
+    into("$buildDir/classes/kotlin/main")
+    from(tasks.processResources.get().destinationDir)
+}


### PR DESCRIPTION
I'm sorry, The migration had a bug this fixes. See anatawa12/migrating-ForgeGradle-3.2-to-4.x#1
